### PR TITLE
bugfix: cache never resized

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -12,7 +12,7 @@ const DEFAULT_STATE = Immutable.Map({
 
 
 const SHRINK_RATIO = 0.25;
-const SHRINK_THRESCHOLD = 1;
+const SHRINK_THRESHOLD = 1;
 
 
 function removeOldKeys(state) {
@@ -78,7 +78,7 @@ export default class Cache {
     const state = this._state;
     let newState = state;
 
-    if (state.size >= this._props.maxSize * SHRINK_THRESCHOLD) {
+    if (state.get('map').size >= this._props.maxSize * SHRINK_THRESHOLD) {
       newState = removeOldKeys(state);
     }
 


### PR DESCRIPTION
At line 81 state.size only ever returns 1, therefore the cache is never resized. Using state.get('map').size returns the true size of the cache.