### PR TITLE
bugfix: cache never resized

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immutable-cache",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Immutable.js enabled caching",
   "main": "index.js",
   "scripts": {

--- a/src/cache.js
+++ b/src/cache.js
@@ -12,7 +12,7 @@ const DEFAULT_STATE = Immutable.Map({
 
 
 const SHRINK_RATIO = 0.25;
-const SHRINK_THRESCHOLD = 1;
+const SHRINK_THRESHOLD = 1;
 
 
 function removeOldKeys(state) {
@@ -78,7 +78,7 @@ export default class Cache {
     const state = this._state;
     let newState = state;
 
-    if (state.size >= this._props.maxSize * SHRINK_THRESCHOLD) {
+    if (state.get('map').size >= this._props.maxSize * SHRINK_THRESHOLD) {
       newState = removeOldKeys(state);
     }
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -64,14 +64,16 @@ describe('Cache', () => {
 
   it('can have limited size', () => {
     let cache = new Cache({
-      maxSize: 1
+      maxSize: 2
     });
 
     cache = cache.set('discard', 'value 1');
     cache = cache.set('keep', 'value 2');
+    cache = cache.set('also', 'value 3');
 
     expect(cache.has('discard')).to.equal(false);
     expect(cache.has('keep')).to.equal(true);
+    expect(cache.has('also')).to.equal(true);
   });
 
 });


### PR DESCRIPTION
At line 81 state.size only ever returns 1, therefore the cache is never resized. Using state.get('map').size returns the true size of the cache.
